### PR TITLE
Change the PKGBUILD and usage.install, to match the changes proposed …

### DIFF
--- a/mkinitcpio-colors-git/PKGBUILD
+++ b/mkinitcpio-colors-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgname=${_pkgname}-git
 pkgdesc="mkinitcpio hook to set VT console colors during early userspace"
 license=('MIT')
 url="https://github.com/EvanPurkhiser/${_pkgname}"
-pkgver=9.5264b13
+pkgver=11.ac5765f
 pkgrel=1
 
 source=("$pkgname::git+$url.git")
@@ -25,6 +25,9 @@ package() {
 
     install -Dm 644 hooks/colors "${pkgdir}/usr/lib/initcpio/hooks/colors"
     install -Dm 644 install/colors "${pkgdir}/usr/lib/initcpio/install/colors"
+    install -Dm 644 install/sd-colors "${pkgdir}/usr/lib/initcpio/install/sd-colors"
+
+    install -Dm 644 setcolors.service "${pkgdir}/usr/lib/systemd/system/setcolors.service"
 
     install -Dm 644 "LICENSE" "${pkgdir}/usr/share/licenses/${_pkgname}/LICENSE"
 }

--- a/mkinitcpio-colors-git/usage.install
+++ b/mkinitcpio-colors-git/usage.install
@@ -3,6 +3,8 @@ post_install() {
 	echo "Define your colors in the /etc/vconsole.conf file as COLOR_X=hexcode"
 	echo "where X is a number between 0 and 15"
 	echo ""
-	echo "Don't forget to add the colors hook in your /etc/mkinitcpio.conf!"
-	echo ""
+	echo "Don't forget to add the colors hook in your /etc/mkinitcpio.conf"
+        echo "If you're using systemd based initramfs, you have to use the sd-colors hook and enable the systemd service:"
+	echo "# systemctl enable setcolors.service"
+        echo ""
 }


### PR DESCRIPTION
…in https://github.com/EvanPurkhiser/mkinitcpio-colors/pull/8

I would not recommend getting any more verbose in `usage.install` for 2 reasons.

1. `usage.install` should be boiled down to the very essence, which would be to not forget adding the hook to ones `/etc/mkinitcpio.conf`, as well as using `sd-colors` and enabling the `systemd` service, if one needs it
2. Atm people running a `systemd` based `initramfs` don't need any further information, as they will probably be used to switching out `busybox` hooks for `systemd` ones and a little bit of tweaking in a `busybox` dominated Arch world